### PR TITLE
#4 fixed hashing method

### DIFF
--- a/msa_exporter.py
+++ b/msa_exporter.py
@@ -805,7 +805,7 @@ def scrap_msa(metrics_store, host, login, password):
     session = requests.Session()
     session.verify = False
 
-    creds = hashlib.md5(b'%s_%s' % (login.encode('utf8'), password.encode('utf8'))).hexdigest()
+    creds = hashlib.sha256(b'%s_%s' % (login.encode('utf8'), password.encode('utf8'))).hexdigest()
     response = session.get('https://%s/api/login/%s' % (host, creds))
     response.raise_for_status()
     session_key = ET.fromstring(response.content)[0][2].text


### PR DESCRIPTION
Currently msa is using sha256 for hashing the username and password. If you're having md5, it gives authentication 401 error. Refer: https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-a00017709en_us (Page 15)